### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+        name: Lint
+      - run: npm run typecheck
+        name: Type check
+      - run: npm test
+        name: Test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow using Node.js 22 to run lint, type check, and tests

## Testing
- `npm run lint` (fails: Missing script "lint")
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897cef35ec0832c8d1ab9006332fca5