### PR TITLE
build: emit type declarations in lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "dev": "vite",
         "build": "tsc && vite build",
-        "build-lib": "tsc && vite build --config vite.config.lib.ts",
+        "build-lib": "tsc -p tsconfig.build.json && vite build --config vite.config.lib.ts",
         "preview": "vite preview",
         "test": "vitest",
         "typecheck": "tsc --noEmit",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": false,
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "outDir": "lib"
+    }
+}

--- a/vite.config.lib.ts
+++ b/vite.config.lib.ts
@@ -7,6 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
     build: {
         outDir: "lib",
+        emptyOutDir: false,
         lib: {
             entry: resolve(__dirname, "src/Pinchable/index.ts"),
             name: "pinchable",


### PR DESCRIPTION
## Summary
- emit declaration files using a dedicated tsconfig.build.json
- run library builds with the new config and keep generated types

## Testing
- `npm run build-lib`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899230b99bc832ca2805053f9821670