### PR TITLE
chore: define package entry points and exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,17 @@
     "version": "0.0.0",
     "type": "module",
     "license": "MIT",
+    "main": "./lib/pinchable.umd.cjs",
+    "module": "./lib/pinchable.js",
+    "types": "./lib/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/pinchable.js",
+            "require": "./lib/pinchable.umd.cjs",
+            "default": "./lib/pinchable.js"
+        }
+    },
     "scripts": {
         "dev": "vite",
         "build": "tsc && vite build",


### PR DESCRIPTION
## Summary
- expose build outputs via `main`, `module`, and `types` fields
- add conditional `exports` map for import/require and type definitions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899292daf3c832cbad9025ea9909bad