### PR TITLE
Ensure ResettableFlag resets value on dispose

### DIFF
--- a/src/ResettableFlag/ResettableFlag.spec.ts
+++ b/src/ResettableFlag/ResettableFlag.spec.ts
@@ -60,4 +60,15 @@ describe("ResettableFlag", () => {
 
         expect(vi.getTimerCount()).toBe(0);
     });
+
+    test("should leave value false when disposed", () => {
+        const flag = new ResettableFlag();
+
+        flag.reset();
+        expect(flag.value).toBe(true);
+
+        flag.dispose();
+
+        expect(flag.value).toBe(false);
+    });
 });

--- a/src/ResettableFlag/ResettableFlag.ts
+++ b/src/ResettableFlag/ResettableFlag.ts
@@ -29,5 +29,6 @@ export class ResettableFlag implements Disposable {
         if (this.resetTimeout !== null) {
             window.clearTimeout(this.resetTimeout);
         }
+        this._value = false;
     }
 }


### PR DESCRIPTION
## Summary
- Explicitly clear flag value when disposing a ResettableFlag
- Test that disposing a flag leaves its value false

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689937ca0148832ca58eaf6194e4752d