### PR TITLE
Clarify focus normalization and clamp out-of-range values

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Interactive demo: https://pinch-six.vercel.app/
 
 - Smooth pinch-zoom with the touch center anchored.
 - Panning with edge clamping and subtle thresholding for a natural feel.
-- Programmatic `focus()` to zoom to a specific point.
+- Programmatic `focus()` to zoom to a specific point using normalized `[0..1]` coordinates.
 - `setEnabled()` to toggle gestures on the fly.
 - Clean `dispose()` teardown.
 - Works with any DOM element.
@@ -31,7 +31,7 @@ const pinchable = new Pinchable(container, {
 // Programmatically zoom to a point
 pinchable.focus({
     zoom: 2,
-    to: { x: 0.5, y: 0.5 }, // relative coordinates inside the element
+    to: { x: 0.5, y: 0.5 }, // values between 0 and 1 (others will be clamped)
 });
 
 // Disable/enable gestures
@@ -41,6 +41,8 @@ pinchable.setEnabled(true);
 // Clean up when done
 pinchable.dispose();
 ```
+
+`focus()` expects the `to` coordinates to be normalized between `0` and `1` relative to the element size; values outside this range are clamped.
 
 ## Compatibility
 

--- a/src/Pinchable/Pinchable.demo.html
+++ b/src/Pinchable/Pinchable.demo.html
@@ -63,8 +63,8 @@
                 <li>Smart edges — content clamps to bounds; tiny reverse motions near edges don’t jitter.</li>
                 <li>Max-zoom hysteresis — small reverse motions after hitting the limit won’t snap out.</li>
                 <li>
-                    Programmatic <code>focus()</code> to smoothly zoom to a target point; temporarily disables manual
-                    gestures while applying.
+                    Programmatic <code>focus()</code> to smoothly zoom to a target point using normalized [0..1]
+                    coordinates; temporarily disables manual gestures while applying.
                 </li>
                 <li>Enable/disable gestures on the fly; clean teardown.</li>
             </ul>

--- a/src/Pinchable/Pinchable.spec.ts
+++ b/src/Pinchable/Pinchable.spec.ts
@@ -610,6 +610,19 @@ describe("Pinch", () => {
                 y: -400,
             });
         });
+
+        test("should clamp focus coordinates to element bounds", () => {
+            const { pinchable } = createPinch();
+            pinchable.focus({
+                zoom: 2,
+                to: { x: -0.5, y: 1.5 },
+            });
+            expect(getLastTransform()).toEqual({
+                zoom: 2,
+                translate: { x: 0, y: -200 },
+                withTransition: true,
+            });
+        });
     });
 
     test("should not allow manual pinch when disabled", () => {

--- a/src/Pinchable/Pinchable.ts
+++ b/src/Pinchable/Pinchable.ts
@@ -57,6 +57,15 @@ export class Pinchable implements Disposable {
         this.startPinchingCallbacks = [];
     }
 
+    /**
+     * Programmatically zoom the element to a specific point.
+     *
+     * @param zoom Optional zoom level to apply.
+     * @param to   Target point inside the element. `to.x` and `to.y`
+     *             should be normalized between `0` and `1`, representing
+     *             a position relative to the element's width and height.
+     *             Values outside this range will be clamped.
+     */
     public focus({ zoom, to }: { zoom?: number; to: { x: number; y: number } }): void {
         this.disableAfterApply.reset();
         if (zoom !== undefined) {
@@ -65,9 +74,14 @@ export class Pinchable implements Disposable {
 
         const { width, height } = this.element.startSize;
 
+        const normalizedTo = {
+            x: clamp(to.x, 0, 1),
+            y: clamp(to.y, 0, 1),
+        };
+
         const centerShift = {
-            x: width / 2 - to.x * width * this.normalizedZoom,
-            y: height / 2 - to.y * height * this.normalizedZoom,
+            x: width / 2 - normalizedTo.x * width * this.normalizedZoom,
+            y: height / 2 - normalizedTo.y * height * this.normalizedZoom,
         };
 
         this.shift = {


### PR DESCRIPTION
## Summary
- Document focus coordinates and clamp them within `[0,1]`
- Test clamping behavior for programmatic focus
- Explain normalized `focus()` coordinates in README and demo

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68993834e5bc832ca2986edfc46273cc