### PR TITLE
fix: correct ResettableFlag default value test name

### DIFF
--- a/src/ResettableFlag/ResettableFlag.spec.ts
+++ b/src/ResettableFlag/ResettableFlag.spec.ts
@@ -9,7 +9,7 @@ describe("ResettableFlag", () => {
         await vi.runAllTimersAsync();
     });
 
-    test("should have value=true by default", () => {
+    test("should have value=false by default", () => {
         const flag = new ResettableFlag();
         expect(flag.value).toBe(false);
     });


### PR DESCRIPTION
## Summary
- rename default value test for `ResettableFlag` to expect false

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899376f7a8c832cb8bc5b486143007f