### PR TITLE
feat: reset styles when PinchedElementWrapper disposed

### DIFF
--- a/src/Pinchable/Pinchable.spec.ts
+++ b/src/Pinchable/Pinchable.spec.ts
@@ -54,6 +54,7 @@ describe("Pinch", () => {
                         return startSize;
                     },
                     transform: vi.fn(),
+                    dispose: vi.fn(),
                 }) as unknown as PinchedElementWrapper,
         );
     });
@@ -651,11 +652,12 @@ describe("Pinch", () => {
         });
     });
 
-    test("should dispose RawPinchDetector on dispose", () => {
+    test("should dispose PinchedElementWrapper and RawPinchDetector on dispose", () => {
         const { pinchable } = createPinch();
         pinchable.dispose();
 
         expect(getRawDetectorInstance().dispose).toHaveBeenCalled();
+        expect(getPinchedElementWrapperInstance().dispose).toHaveBeenCalled();
     });
 
     test("should dispose after apply daily", () => {

--- a/src/Pinchable/Pinchable.ts
+++ b/src/Pinchable/Pinchable.ts
@@ -54,6 +54,7 @@ export class Pinchable implements Disposable {
     public dispose(): void {
         this.rawPinchDetector.dispose();
         this.disableAfterApply.dispose();
+        this.element.dispose();
         this.startPinchingCallbacks.clear();
     }
 

--- a/src/PinchedElementWrapper/PinchedElementWrapper.demo.ts
+++ b/src/PinchedElementWrapper/PinchedElementWrapper.demo.ts
@@ -27,6 +27,7 @@ function initPinchedElementWrapperDemo() {
 
     moveTimeInput.addEventListener("change", () => {
         moveTime = parseInt(moveTimeInput.value, 10);
+        pinchedElementWrapper.dispose();
         pinchedElementWrapper = new PinchedElementWrapper(element, moveTime);
     });
 

--- a/src/PinchedElementWrapper/PinchedElementWrapper.spec.ts
+++ b/src/PinchedElementWrapper/PinchedElementWrapper.spec.ts
@@ -62,10 +62,11 @@ describe("PinchedElementWrapper", () => {
         expect(wrapper.startSize).toEqual({ width: 100, height: 200 });
     });
 
-    test("should set correct initial styles on element", () => {
+    test("should set transformOrigin without changing position", () => {
+        element.style.position = "absolute";
         new PinchedElementWrapper(element, 300);
 
-        expect(element.style.position).toBe("relative");
+        expect(element.style.position).toBe("absolute");
         expect(element.style.transformOrigin).toBe("top left");
     });
 
@@ -150,5 +151,34 @@ describe("PinchedElementWrapper", () => {
 
         await waitNextAnimationFrame();
         expect(element.style.transition).toBe("");
+    });
+
+    test("should restore original styles on dispose", async () => {
+        element.style.position = "absolute";
+        element.style.transformOrigin = "center";
+        element.style.transform = "scale(2)";
+        element.style.transition = "all 1s ease";
+
+        const wrapper = new PinchedElementWrapper(element, 300);
+
+        wrapper.transform({
+            zoom: 1.5,
+            translate: { x: 10, y: 20 },
+            withTransition: true,
+        });
+
+        await waitNextAnimationFrame();
+
+        expect(element.style.position).toBe("absolute");
+        expect(element.style.transformOrigin).toBe("top left");
+        expect(element.style.transform).not.toBe("scale(2)");
+        expect(element.style.transition).toBe("transform 0.3s ease");
+
+        wrapper.dispose();
+
+        expect(element.style.position).toBe("absolute");
+        expect(element.style.transformOrigin).toBe("center");
+        expect(element.style.transform).toBe("scale(2)");
+        expect(element.style.transition).toBe("all 1s ease");
     });
 });

--- a/src/PinchedElementWrapper/PinchedElementWrapper.ts
+++ b/src/PinchedElementWrapper/PinchedElementWrapper.ts
@@ -8,6 +8,11 @@ export class PinchedElementWrapper {
     private readonly _startSize: { width: number; height: number };
     private readonly element: HTMLElement;
     private readonly moveTime: number;
+    private readonly initialStyles: {
+        transformOrigin: string;
+        transform: string;
+        transition: string;
+    };
     private isTransformRequested = false;
     private transformData: TransformData = {
         zoom: 1,
@@ -18,8 +23,11 @@ export class PinchedElementWrapper {
     public constructor(element: HTMLElement, moveTime: number) {
         this.moveTime = moveTime;
         this.element = element;
-        // we do not remove this styles, but it is ok
-        element.style.position = "relative";
+        this.initialStyles = {
+            transformOrigin: element.style.transformOrigin,
+            transform: element.style.transform,
+            transition: element.style.transition,
+        };
         element.style.transformOrigin = "top left";
         const rect = element.getBoundingClientRect();
         this._startSize = { width: rect.width, height: rect.height };
@@ -45,5 +53,11 @@ export class PinchedElementWrapper {
             }
             this.isTransformRequested = false;
         });
+    }
+
+    public dispose(): void {
+        this.element.style.transformOrigin = this.initialStyles.transformOrigin;
+        this.element.style.transform = this.initialStyles.transform;
+        this.element.style.transition = this.initialStyles.transition;
     }
 }


### PR DESCRIPTION
## Summary
- restore original element styles in `PinchedElementWrapper.dispose`
- ensure Pinchable calls `dispose()` on its wrapper
- add tests for style restoration and PinchedElementWrapper disposal
- avoid changing element `position` style

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899b7b5a9fc832cbcf3410b11544f50