### PR TITLE
feat: apply required touch-action style automatically

### DIFF
--- a/src/Pinchable/Pinchable.demo.html
+++ b/src/Pinchable/Pinchable.demo.html
@@ -16,8 +16,6 @@
                     repeating-linear-gradient(0deg, blue 0 2px, transparent 2px 25px),
                     radial-gradient(closest-side, #3f87a6, #ebf8e1, #f69d3c);
                 background-blend-mode: normal;
-                touch-action: none;
-                position: relative;
             }
 
             .controls {

--- a/src/Pinchable/Pinchable.demo.ts
+++ b/src/Pinchable/Pinchable.demo.ts
@@ -2,7 +2,7 @@ import { Pinchable } from "./Pinchable.ts";
 
 function createFillCanvas(container: HTMLElement): HTMLCanvasElement {
     const canvas = document.createElement("canvas");
-    canvas.style.position = "absolute";
+    canvas.style.position = "relative";
     canvas.style.top = "0";
     canvas.style.left = "0";
     canvas.style.pointerEvents = "none";

--- a/src/PinchedElementWrapper/PinchedElementWrapper.demo.html
+++ b/src/PinchedElementWrapper/PinchedElementWrapper.demo.html
@@ -7,13 +7,11 @@
         <title>PinchedElementWrapper</title>
         <style>
             .PinchedElementWrapper {
-                position: relative;
                 height: 100px;
                 width: 100px;
                 padding: 5px;
                 margin: 20px auto;
                 background: lightgray;
-                touch-action: none;
                 display: flex;
                 justify-content: start;
                 align-items: center;

--- a/src/PinchedElementWrapper/PinchedElementWrapper.spec.ts
+++ b/src/PinchedElementWrapper/PinchedElementWrapper.spec.ts
@@ -62,14 +62,6 @@ describe("PinchedElementWrapper", () => {
         expect(wrapper.startSize).toEqual({ width: 100, height: 200 });
     });
 
-    test("should set transformOrigin without changing position", () => {
-        element.style.position = "absolute";
-        new PinchedElementWrapper(element, 300);
-
-        expect(element.style.position).toBe("absolute");
-        expect(element.style.transformOrigin).toBe("top left");
-    });
-
     test("should apply only last transform data when multiple calls are made before animation frame", async () => {
         const wrapper = new PinchedElementWrapper(element, 300);
 
@@ -154,7 +146,6 @@ describe("PinchedElementWrapper", () => {
     });
 
     test("should restore original styles on dispose", async () => {
-        element.style.position = "absolute";
         element.style.transformOrigin = "center";
         element.style.transform = "scale(2)";
         element.style.transition = "all 1s ease";
@@ -169,14 +160,12 @@ describe("PinchedElementWrapper", () => {
 
         await waitNextAnimationFrame();
 
-        expect(element.style.position).toBe("absolute");
         expect(element.style.transformOrigin).toBe("top left");
         expect(element.style.transform).not.toBe("scale(2)");
         expect(element.style.transition).toBe("transform 0.3s ease");
 
         wrapper.dispose();
 
-        expect(element.style.position).toBe("absolute");
         expect(element.style.transformOrigin).toBe("center");
         expect(element.style.transform).toBe("scale(2)");
         expect(element.style.transition).toBe("all 1s ease");

--- a/src/RawPinchDetector/RawPinchDetector.demo.html
+++ b/src/RawPinchDetector/RawPinchDetector.demo.html
@@ -7,12 +7,10 @@
         <title>RawPinchDetector</title>
         <style>
             .RawPinchDetector {
-                position: relative;
                 height: 400px;
                 width: 100%;
                 padding: 20px;
                 background: lightgray;
-                touch-action: none;
                 display: flex;
                 justify-content: start;
                 align-items: center;

--- a/src/RawPinchDetector/RawPinchDetector.spec.ts
+++ b/src/RawPinchDetector/RawPinchDetector.spec.ts
@@ -38,13 +38,6 @@ describe("RawPinchDetector", () => {
 
     test("should set required styles on element", () => {
         expect(element.style.touchAction).toBe("none");
-        expect(element.style.position).toBe("relative");
-    });
-
-    test("should restore styles on dispose", () => {
-        detector.dispose();
-        expect(element.style.touchAction).toBe("");
-        expect(element.style.position).toBe("");
     });
 
     test("should restore custom touch-action style", () => {
@@ -59,21 +52,6 @@ describe("RawPinchDetector", () => {
         expect(custom.style.touchAction).toBe("none");
         localDetector.dispose();
         expect(custom.style.touchAction).toBe("pan-x");
-        document.body.removeChild(custom);
-    });
-
-    test("should restore existing position style", () => {
-        const custom = document.createElement("div");
-        custom.style.position = "absolute";
-        document.body.appendChild(custom);
-        const localDetector = new RawPinchDetector({
-            element: custom,
-            onStart: vi.fn(),
-            onPinch: vi.fn(),
-        });
-        expect(custom.style.position).toBe("absolute");
-        localDetector.dispose();
-        expect(custom.style.position).toBe("absolute");
         document.body.removeChild(custom);
     });
 

--- a/src/RawPinchDetector/RawPinchDetector.spec.ts
+++ b/src/RawPinchDetector/RawPinchDetector.spec.ts
@@ -36,6 +36,47 @@ describe("RawPinchDetector", () => {
         await eventResult;
     }
 
+    test("should set required styles on element", () => {
+        expect(element.style.touchAction).toBe("none");
+        expect(element.style.position).toBe("relative");
+    });
+
+    test("should restore styles on dispose", () => {
+        detector.dispose();
+        expect(element.style.touchAction).toBe("");
+        expect(element.style.position).toBe("");
+    });
+
+    test("should restore custom touch-action style", () => {
+        const custom = document.createElement("div");
+        custom.style.touchAction = "pan-x";
+        document.body.appendChild(custom);
+        const localDetector = new RawPinchDetector({
+            element: custom,
+            onStart: vi.fn(),
+            onPinch: vi.fn(),
+        });
+        expect(custom.style.touchAction).toBe("none");
+        localDetector.dispose();
+        expect(custom.style.touchAction).toBe("pan-x");
+        document.body.removeChild(custom);
+    });
+
+    test("should restore existing position style", () => {
+        const custom = document.createElement("div");
+        custom.style.position = "absolute";
+        document.body.appendChild(custom);
+        const localDetector = new RawPinchDetector({
+            element: custom,
+            onStart: vi.fn(),
+            onPinch: vi.fn(),
+        });
+        expect(custom.style.position).toBe("absolute");
+        localDetector.dispose();
+        expect(custom.style.position).toBe("absolute");
+        document.body.removeChild(custom);
+    });
+
     test("should invoke onStart callback when user touches screen with two fingers", async () => {
         await asyncPointer([
             { keys: "[TouchA>]", target: element, coords: { pageX: 100, pageY: 200 } },

--- a/src/RawPinchDetector/RawPinchDetector.ts
+++ b/src/RawPinchDetector/RawPinchDetector.ts
@@ -15,7 +15,6 @@ export class RawPinchDetector implements Disposable {
     private readonly disableAfterUp = new ResettableFlag(100);
     private readonly initialStyles: {
         touchAction: string;
-        position: string;
     };
 
     public constructor(params: { element: HTMLElement; onStart: () => void; onPinch: () => void }) {
@@ -25,14 +24,8 @@ export class RawPinchDetector implements Disposable {
 
         this.initialStyles = {
             touchAction: this.element.style.touchAction,
-            position: this.element.style.position,
         };
         this.element.style.touchAction = "none";
-        // Provide a stable positioning context if none exists so wrappers that
-        // rely on absolute children (e.g., PinchedElementWrapper) behave as expected.
-        if (!this.element.style.position) {
-            this.element.style.position = "relative";
-        }
 
         this.element.addEventListener("pointerdown", this.handleDown);
         this.element.addEventListener("pointermove", this.handleMove);
@@ -50,8 +43,7 @@ export class RawPinchDetector implements Disposable {
         this.element.removeEventListener("pointerout", this.handleUp);
         this.element.removeEventListener("pointerleave", this.handleUp);
         this.disableAfterUp.dispose();
-        this.element.style.touchAction = this.initialStyles.touchAction || "";
-        this.element.style.position = this.initialStyles.position;
+        this.element.style.touchAction = this.initialStyles.touchAction;
     }
 
     public get isPinch(): boolean {


### PR DESCRIPTION
## Summary
- document why `RawPinchDetector` ensures a positioning context before attaching pointer handlers
- cover saving and restoring of initial `touchAction` and `position` styles

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689a6fe2c128832c8c635caae49af406