### PR TITLE
Allow zooming below 1 with minZoom parameter

### DIFF
--- a/src/Pinchable/Pinchable.spec.ts
+++ b/src/Pinchable/Pinchable.spec.ts
@@ -206,6 +206,35 @@ describe("Pinch", () => {
             expect(getLastTransform().zoom).toEqual(1);
         });
 
+        test("zoom can be smaller then 1 with provided minZoom", () => {
+            const pinch = createPinch({ minZoom: 0.5 });
+            pinch.start({
+                center: { x: 40, y: 40 },
+                distance: 50,
+            });
+            pinch.move({
+                distance: 40,
+            });
+            expect(getLastTransform().zoom).toEqual(1);
+            pinch.move({
+                distance: 25,
+            });
+            const transform = getLastTransform();
+            expect(transform.zoom).toBeCloseTo(0.625);
+            expect(transform.translate).toEqual({
+                x: (startSize.width * (1 - transform.zoom)) / 2,
+                y: (startSize.height * (1 - transform.zoom)) / 2,
+            });
+            pinch.move({
+                distance: 5,
+            });
+            expect(getLastTransform()).toEqual({
+                zoom: 0.5,
+                translate: { x: 75, y: 50 },
+                withTransition: false,
+            });
+        });
+
         test("should change zoom with passed velocity", () => {
             const pinch = createPinch({ velocity: 0.5 });
             pinch.start({


### PR DESCRIPTION
## Summary
- add optional `minZoom` parameter to Pinchable
- allow zooming below 1 with threshold and centering when minZoom < 1
- cover new behavior with tests

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c5b76ec64832cb3acf32ccc61551a