### PR TITLE
feat: allow zooming out below 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ const container = document.getElementById("photo") as HTMLElement;
 
 const pinchable = new Pinchable(container, {
     maxZoom: 3, // maximum zoom scale
+    minZoom: 0.5, // minimum zoom scale (1 = original size, default is 1)
     velocity: 0.7, // pinch sensitivity
     applyTime: 400, // ms transition when programmatically focusing
 });
@@ -50,7 +51,7 @@ pinchable.setEnabled(true);
 pinchable.dispose();
 ```
 
-`focus()` expects the `to` coordinates to be normalized between `0` and `1` relative to the element size; values outside this range are clamped.
+`minZoom` defaults to `1`, preventing zooming out beyond the original size. Set it lower to allow zooming out while keeping the element centered. `focus()` expects the `to` coordinates to be normalized between `0` and `1` relative to the element size; values outside this range are clamped.
 
 ## Compatibility
 

--- a/src/Pinchable/Pinchable.demo.html
+++ b/src/Pinchable/Pinchable.demo.html
@@ -86,6 +86,11 @@
                     <span id="maxZoomValue">2.5</span>
                 </div>
                 <div class="setting-row">
+                    <label for="minZoom">Min Zoom:</label>
+                    <input type="range" id="minZoom" value="0.5" min="0.1" max="1" step="0.1" />
+                    <span id="minZoomValue">1</span>
+                </div>
+                <div class="setting-row">
                     <label for="velocity">Velocity:</label>
                     <input type="range" id="velocity" value="0.7" min="0.1" max="2" step="0.1" />
                     <span id="velocityValue">0.7</span>
@@ -95,16 +100,27 @@
                     <input type="range" id="applyTime" value="400" min="100" max="2000" step="50" />
                     <span id="applyTimeValue">400</span>
                 </div>
+                <div class="setting-row">
+                    <label for="zoomThreshold">Zoom Threshold:</label>
+                    <input type="range" id="zoomThreshold" value="0.2" min="0" max="0.5" step="0.01" />
+                    <span id="zoomThresholdValue">0.2</span>
+                </div>
+                <div class="setting-row">
+                    <label for="shiftThreshold">Shift Threshold:</label>
+                    <input type="range" id="shiftThreshold" value="10" min="0" max="50" step="1" />
+                    <span id="shiftThresholdValue">10</span>
+                </div>
             </div>
 
             <div class="controls">
+                <button id="disableButton">Disable</button>
+                <button id="enableButton">Enable</button>
                 <button id="resetButton">Reset</button>
                 <button id="movePoint1">Move to (0.2, 0.5)</button>
                 <button id="movePoint2">Move to (0.9, 0.8)</button>
                 <button id="movePoint3">Move to (0.5, 0.1)</button>
                 <button id="movePoint4">Move to (0.4, 0.7)</button>
-                <button id="disableButton">Disable</button>
-                <button id="enableButton">Enable</button>
+                <button id="zoomLessThanOne">Zoom less than 1</button>
             </div>
         </article>
         <div class="pinchable-container" id="pinchContainer"></div>

--- a/src/Pinchable/Pinchable.demo.ts
+++ b/src/Pinchable/Pinchable.demo.ts
@@ -45,19 +45,48 @@ export function initPinchableDemo(): void {
     const container = document.getElementById("pinchContainer") as HTMLDivElement;
     const maxZoomInput = document.getElementById("maxZoom") as HTMLInputElement;
     const maxZoomValue = document.getElementById("maxZoomValue") as HTMLSpanElement;
+    const minZoomInput = document.getElementById("minZoom") as HTMLInputElement;
+    const minZoomValue = document.getElementById("minZoomValue") as HTMLSpanElement;
     const velocityInput = document.getElementById("velocity") as HTMLInputElement;
     const velocityValue = document.getElementById("velocityValue") as HTMLSpanElement;
     const applyTimeInput = document.getElementById("applyTime") as HTMLInputElement;
     const applyTimeValue = document.getElementById("applyTimeValue") as HTMLSpanElement;
+    const zoomThresholdInput = document.getElementById("zoomThreshold") as HTMLInputElement;
+    const zoomThresholdValue = document.getElementById("zoomThresholdValue") as HTMLSpanElement;
+    const shiftThresholdInput = document.getElementById("shiftThreshold") as HTMLInputElement;
+    const shiftThresholdValue = document.getElementById("shiftThresholdValue") as HTMLSpanElement;
     const resetButton = document.getElementById("resetButton") as HTMLButtonElement;
     const movePoint1 = document.getElementById("movePoint1") as HTMLButtonElement;
     const movePoint2 = document.getElementById("movePoint2") as HTMLButtonElement;
     const movePoint3 = document.getElementById("movePoint3") as HTMLButtonElement;
     const movePoint4 = document.getElementById("movePoint4") as HTMLButtonElement;
+    const zoomLessThanOne = document.getElementById("zoomLessThanOne") as HTMLButtonElement;
     const disableButton = document.getElementById("disableButton") as HTMLButtonElement;
     const enableButton = document.getElementById("enableButton") as HTMLButtonElement;
 
-    if (!container || !maxZoomInput || !velocityInput || !applyTimeInput || !resetButton) {
+    if (
+        !container ||
+        !maxZoomInput ||
+        !minZoomInput ||
+        !velocityInput ||
+        !applyTimeInput ||
+        !resetButton ||
+        !movePoint1 ||
+        !movePoint2 ||
+        !movePoint3 ||
+        !movePoint4 ||
+        !zoomLessThanOne ||
+        !disableButton ||
+        !enableButton ||
+        !maxZoomValue ||
+        !minZoomValue ||
+        !velocityValue ||
+        !applyTimeValue ||
+        !zoomThresholdInput ||
+        !zoomThresholdValue ||
+        !shiftThresholdInput ||
+        !shiftThresholdValue
+    ) {
         console.error("Required elements not found in the document.");
         return;
     }
@@ -72,27 +101,42 @@ export function initPinchableDemo(): void {
 
     // Initialize parameters
     let maxZoom = parseFloat(maxZoomInput.value);
+    let minZoom = parseFloat(minZoomInput.value);
     let velocity = parseFloat(velocityInput.value);
     let applyTime = parseInt(applyTimeInput.value, 10);
+    let zoomThreshold = parseFloat(zoomThresholdInput.value);
+    let shiftThreshold = parseInt(shiftThresholdInput.value, 10);
 
     // Create Pinchable instance
     let pinchable = new Pinchable(container, {
         maxZoom: maxZoom,
+        minZoom: minZoom,
         velocity: velocity,
         applyTime: applyTime,
+        zoomThreshold: zoomThreshold,
+        shiftThreshold: shiftThreshold,
     });
 
     // Update value displays
     function updateValueDisplays(): void {
         maxZoomValue.textContent = maxZoom.toString();
+        minZoomValue.textContent = minZoom.toString();
         velocityValue.textContent = velocity.toString();
         applyTimeValue.textContent = applyTime.toString();
+        zoomThresholdValue.textContent = zoomThreshold.toFixed(2);
+        shiftThresholdValue.textContent = shiftThreshold.toString();
     }
     updateValueDisplays();
 
     // Handle parameter changes
     maxZoomInput.addEventListener("input", () => {
         maxZoom = parseFloat(maxZoomInput.value);
+        updateValueDisplays();
+        reinitializePinchable();
+    });
+
+    minZoomInput.addEventListener("input", () => {
+        minZoom = parseFloat(minZoomInput.value);
         updateValueDisplays();
         reinitializePinchable();
     });
@@ -109,12 +153,27 @@ export function initPinchableDemo(): void {
         reinitializePinchable();
     });
 
+    zoomThresholdInput.addEventListener("input", () => {
+        zoomThreshold = parseFloat(zoomThresholdInput.value);
+        updateValueDisplays();
+        reinitializePinchable();
+    });
+
+    shiftThresholdInput.addEventListener("input", () => {
+        shiftThreshold = parseInt(shiftThresholdInput.value, 10);
+        updateValueDisplays();
+        reinitializePinchable();
+    });
+
     function reinitializePinchable(): void {
         pinchable.dispose();
         pinchable = new Pinchable(container, {
             maxZoom: maxZoom,
+            minZoom: minZoom,
             velocity: velocity,
             applyTime: applyTime,
+            zoomThreshold: zoomThreshold,
+            shiftThreshold: shiftThreshold,
         });
     }
 
@@ -151,6 +210,13 @@ export function initPinchableDemo(): void {
         pinchable.focus({
             zoom: 1.5,
             to: { x: 0.4, y: 0.7 },
+        });
+    });
+
+    zoomLessThanOne.addEventListener("click", () => {
+        pinchable.focus({
+            zoom: 0.8,
+            to: { x: 1, y: 1 },
         });
     });
 

--- a/src/Pinchable/Pinchable.spec.ts
+++ b/src/Pinchable/Pinchable.spec.ts
@@ -64,6 +64,9 @@ describe("Pinch", () => {
             maxZoom: 3,
             velocity: 1,
             applyTime: 300,
+            minZoom: 1,
+            zoomThreshold: 0.3,
+            shiftThreshold: 10,
         };
         const element = document.createElement("div");
         const pinchable = new Pinchable(element, { ...defaultParams, ...params });
@@ -107,7 +110,7 @@ describe("Pinch", () => {
                 distance: 50,
             });
             pinch.move({
-                distance: 100,
+                distance: 105,
             });
             expect(getLastTransform()).toEqual({
                 zoom: 2,
@@ -126,7 +129,7 @@ describe("Pinch", () => {
                 distance: 70,
             });
             pinch.move({
-                distance: 100,
+                distance: 105,
             });
             expect(getLastTransform()).toEqual({
                 zoom: 2,
@@ -161,7 +164,7 @@ describe("Pinch", () => {
                 distance: 50,
             });
             pinch.move({
-                distance: 75,
+                distance: 80,
             });
             pinch.start({
                 center: { x: 100, y: 20 },
@@ -206,6 +209,52 @@ describe("Pinch", () => {
             expect(getLastTransform().zoom).toEqual(1);
         });
 
+        test("should allow zooming out below 1 when minZoom is provided", () => {
+            const pinch = createPinch({ minZoom: 0.5 });
+            pinch.start({
+                center: { x: 40, y: 40 },
+                distance: 50,
+            });
+            pinch.move({
+                distance: 45,
+                shift: { x: 20, y: 20 },
+            });
+            expect(getLastTransform()).toEqual({
+                zoom: 1,
+                translate: { x: 0, y: 0 },
+                withTransition: false,
+            });
+            pinch.move({
+                distance: 20,
+                shift: { x: -50, y: -50 },
+            });
+            expect(getLastTransform()).toEqual({
+                zoom: 0.5,
+                translate: { x: 75, y: 50 },
+                withTransition: false,
+            });
+        });
+
+        test("should have a small 'trigger slack' near zoom 1", () => {
+            const pinch = createPinch({ minZoom: 0.5 });
+            pinch.start({
+                center: { x: 40, y: 40 },
+                distance: 50,
+            });
+            pinch.move({
+                distance: 55,
+            });
+            expect(getLastTransform().zoom).toBe(1);
+            pinch.move({
+                distance: 45,
+            });
+            expect(getLastTransform().zoom).toBe(1);
+            pinch.move({
+                distance: 40,
+            });
+            expect(getLastTransform().zoom).toBeCloseTo(0.9);
+        });
+
         test("should change zoom with passed velocity", () => {
             const pinch = createPinch({ velocity: 0.5 });
             pinch.start({
@@ -213,7 +262,7 @@ describe("Pinch", () => {
                 distance: 50,
             });
             pinch.move({
-                distance: 150,
+                distance: 200,
             });
 
             expect(getLastTransform().zoom).toEqual(1.5);
@@ -255,9 +304,9 @@ describe("Pinch", () => {
             });
             expect(getLastTransform().zoom).toEqual(2);
             pinch.move({
-                distance: 180, // it is much bigger than 100 = 2 (maxZoom) * 50 (start distance)
+                distance: 180, // it is much bigger than 105 = 2 (maxZoom) * 50 (start distance) + 5 (near one threshold)
             });
-            expect(getLastTransform().zoom).toEqual(1.98);
+            expect(getLastTransform().zoom).toBeCloseTo(1.97);
         });
 
         test("during zooming left/top position of element can be more 0", () => {
@@ -312,7 +361,7 @@ describe("Pinch", () => {
                 distance: 50,
             });
             pinch.move({
-                distance: 100,
+                distance: 105,
             });
             pinch.move({
                 shift: { x: 20, y: 20 },
@@ -331,7 +380,7 @@ describe("Pinch", () => {
                 distance: 50,
             });
             pinch.move({
-                distance: 100,
+                distance: 105,
             });
             pinch.move({
                 shift: { x: 20, y: -10 },
@@ -353,7 +402,7 @@ describe("Pinch", () => {
                 distance: 50,
             });
             pinch.move({
-                distance: 100,
+                distance: 105,
             });
             pinch.move({
                 shift: { x: 30, y: -30 },
@@ -375,7 +424,7 @@ describe("Pinch", () => {
                 distance: 50,
             });
             pinch.move({
-                distance: 100,
+                distance: 105,
             });
             pinch.move({
                 shift: { x: -15, y: 20 },
@@ -402,7 +451,7 @@ describe("Pinch", () => {
                 distance: 50,
             });
             pinch.move({
-                distance: 100,
+                distance: 105,
             });
             pinch.move({
                 shift: { x: 100, y: 100 },
@@ -500,14 +549,14 @@ describe("Pinch", () => {
             });
         });
 
-        test("should preserve focus if it is not provided", () => {
+        test("should preserve zoom focus if it is not provided", () => {
             const { pinchable, ...pinch } = createPinch();
             pinch.start({
                 center: { x: 40, y: 40 },
                 distance: 50,
             });
             pinch.move({
-                distance: 100,
+                distance: 105,
             });
             pinchable.focus({
                 to: {
@@ -529,7 +578,7 @@ describe("Pinch", () => {
                 distance: 50,
             });
             pinch.move({
-                distance: 100,
+                distance: 105,
             });
             pinchable.setEnabled(false);
             pinchable.focus({
@@ -552,7 +601,7 @@ describe("Pinch", () => {
                 distance: 50,
             });
             pinch.move({
-                distance: 100,
+                distance: 105,
             });
             pinchable.focus({
                 to: {
@@ -667,7 +716,7 @@ describe("Pinch", () => {
             distance: 50,
         });
         pinch.move({
-            distance: 100,
+            distance: 105,
         });
         expect(getLastTransform()).toEqual({
             zoom: 2,


### PR DESCRIPTION
## Summary
- add optional `minZoom` parameter to allow zooming out below original size and keep content centered
- document and demo new `minZoom` behavior
- test zooming out and centering behavior

## Testing
- `npm test -- run`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b6c4a73c38832c8126a69c2798c5dc