### PR TITLE
feat: add pinching subscription

### DIFF
--- a/react-demo/src/App.tsx
+++ b/react-demo/src/App.tsx
@@ -21,16 +21,8 @@ function App() {
                 maxZoom: 3,
                 velocity: 0.7,
                 applyTime: 400,
-                minZoom: 0.5,
             });
-            pinch.subscribeToPinching((zoom) => {
-                if (zoom < 0.7) {
-                    setActive(null);
-                }
-            });
-            return () => {
-                pinch.dispose();
-            };
+            return () => pinch.dispose();
         }
     }, [active]);
 

--- a/react-demo/src/App.tsx
+++ b/react-demo/src/App.tsx
@@ -21,8 +21,16 @@ function App() {
                 maxZoom: 3,
                 velocity: 0.7,
                 applyTime: 400,
+                minZoom: 0.5,
             });
-            return () => pinch.dispose();
+            pinch.subscribeToPinching((zoom) => {
+                if (zoom < 0.7) {
+                    setActive(null);
+                }
+            });
+            return () => {
+                pinch.dispose();
+            };
         }
     }, [active]);
 

--- a/src/Pinchable/Pinchable.spec.ts
+++ b/src/Pinchable/Pinchable.spec.ts
@@ -709,6 +709,49 @@ describe("Pinch", () => {
         });
     });
 
+    describe("subscribeToPinching", () => {
+        test("calls callback on pinch", () => {
+            const { pinchable, start, move } = createPinch();
+            const cb = vi.fn();
+            pinchable.subscribeToPinching(cb);
+            start({ center: { x: 40, y: 40 }, distance: 50 });
+            move({ distance: 105 });
+            expect(cb).toHaveBeenCalledWith(2, { x: -40, y: -40 });
+        });
+
+        test("calls callback on focus", () => {
+            const { pinchable } = createPinch();
+            const cb = vi.fn();
+            pinchable.subscribeToPinching(cb);
+            pinchable.focus({ zoom: 2, to: { x: 0.5, y: 0.5 } });
+            expect(cb).toHaveBeenCalledWith(2, { x: -150, y: -100 });
+        });
+
+        test("unsubscribe removes callback", () => {
+            const { pinchable, start, move } = createPinch();
+            const cb = vi.fn();
+            const unsubscribe = pinchable.subscribeToPinching(cb);
+            start({ center: { x: 40, y: 40 }, distance: 50 });
+            move({ distance: 105 });
+            expect(cb).toHaveBeenCalledTimes(1);
+            unsubscribe();
+            move({ distance: 110 });
+            expect(cb).toHaveBeenCalledTimes(1);
+        });
+
+        test("dispose removes callback", () => {
+            const { pinchable, start, move } = createPinch();
+            const cb = vi.fn();
+            pinchable.subscribeToPinching(cb);
+            start({ center: { x: 40, y: 40 }, distance: 50 });
+            move({ distance: 105 });
+            expect(cb).toHaveBeenCalledTimes(1);
+            pinchable.dispose();
+            move({ distance: 110 });
+            expect(cb).toHaveBeenCalledTimes(1);
+        });
+    });
+
     test("should not allow manual pinch when disabled", () => {
         const { pinchable, ...pinch } = createPinch();
         pinch.start({

--- a/src/Pinchable/Pinchable.ts
+++ b/src/Pinchable/Pinchable.ts
@@ -26,6 +26,7 @@ export class Pinchable implements Disposable {
     private disableAfterApply: ResettableFlag;
     private enabled = true;
     private startPinchingNotifier = new Notifier<[]>();
+    private pinchingNotifier = new Notifier<[number, { x: number; y: number }]>();
     // change one per pinch
     private center = { x: 0, y: 0 };
     private prevZoom = 1;
@@ -68,6 +69,7 @@ export class Pinchable implements Disposable {
         this.disableAfterApply.dispose();
         this.element.dispose();
         this.startPinchingNotifier.dispose();
+        this.pinchingNotifier.dispose();
     }
 
     /**
@@ -108,6 +110,7 @@ export class Pinchable implements Disposable {
             translate: this.normalizedShift,
             withTransition: true,
         });
+        this.pinchingNotifier.emit(this.normalizedZoom, this.normalizedShift);
     }
 
     public setEnabled(enabled: boolean): void {
@@ -116,6 +119,10 @@ export class Pinchable implements Disposable {
 
     public subscribeToStartPinching(callback: () => void): () => void {
         return this.startPinchingNotifier.subscribe(callback);
+    }
+
+    public subscribeToPinching(callback: (zoom: number, shift: { x: number; y: number }) => void): () => void {
+        return this.pinchingNotifier.subscribe(callback);
     }
 
     private handleStart = () => {
@@ -150,6 +157,7 @@ export class Pinchable implements Disposable {
             translate: this.normalizedShift,
             withTransition: false,
         });
+        this.pinchingNotifier.emit(this.normalizedZoom, this.normalizedShift);
         this.prevDist = curDist;
     };
 


### PR DESCRIPTION
## Summary
- add `subscribeToPinching` to Pinchable for zoom and shift updates
- support zoom-out handling in React demo with minimum zoom 0.5 and auto-close on low zoom
- cover pinching subscription with unit tests

## Testing
- `npm test`
- `npm --prefix react-demo run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b7888bf9f0832caab5dc75562ceea2