### PR TITLE
feat(react-demo): add close animation

### DIFF
--- a/react-demo/package-lock.json
+++ b/react-demo/package-lock.json
@@ -8,7 +8,7 @@
             "name": "react-demo",
             "version": "0.0.0",
             "dependencies": {
-                "pinchable": "^0.1.4",
+                "pinchable": "^0.1.5",
                 "react": "^19.1.1",
                 "react-dom": "^19.1.1"
             },
@@ -2814,9 +2814,9 @@
             }
         },
         "node_modules/pinchable": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/pinchable/-/pinchable-0.1.4.tgz",
-            "integrity": "sha512-Ci+lpAnp88PIYpBucXQv17ZhQRAWnR+1TAQuDXz+amNHAj8n7GvZU8SFAT9nFwlJUbm/qc92wEBuoAPoXpO+/w==",
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/pinchable/-/pinchable-0.1.5.tgz",
+            "integrity": "sha512-msbzhV1SsZDqmxA29HxeUacDPR/EZPkYKOn33yqO8a7TwQOymBDyK8X6aFf/W5etbyy7kpWfsAKkzB0ROqK+rg==",
             "license": "MIT"
         },
         "node_modules/postcss": {

--- a/react-demo/package.json
+++ b/react-demo/package.json
@@ -11,7 +11,7 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "pinchable": "^0.1.4",
+        "pinchable": "^0.1.5",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
     },

--- a/react-demo/src/App.css
+++ b/react-demo/src/App.css
@@ -26,6 +26,15 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    opacity: 1;
+    transform: scale(1);
+    transform-origin: center;
+    transition: opacity 0.5s ease, transform 0.5s ease;
+}
+
+.overlay.closing {
+    opacity: 0;
+    transform: scale(0.2);
 }
 
 .overlay img {

--- a/react-demo/src/App.tsx
+++ b/react-demo/src/App.tsx
@@ -13,19 +13,37 @@ const images = [
 
 function App() {
     const [active, setActive] = useState<number | null>(null);
+    const [closing, setClosing] = useState(false);
     const imgRef = useRef<HTMLImageElement | null>(null);
+
+    const close = () => {
+        setClosing(true);
+    };
+
+    useEffect(() => {
+        if (closing) {
+            const timer = setTimeout(() => {
+                setActive(null);
+                setClosing(false);
+            }, 500);
+            return () => clearTimeout(timer);
+        }
+    }, [closing]);
 
     useEffect(() => {
         if (active !== null && imgRef.current) {
-            const pinch = new Pinchable(imgRef.current, {
-                maxZoom: 3,
-                minZoom: 0.5,
-                velocity: 0.7,
-                applyTime: 400,
-            });
-            pinch.subscribeToPinching((zoom) => {
-                if (zoom < 0.7) {
-                    setActive(null);
+            const pinch = new Pinchable(
+                imgRef.current,
+                {
+                    maxZoom: 3,
+                    minZoom: 0.5,
+                    velocity: 0.7,
+                    applyTime: 400,
+                },
+            );
+            pinch.subscribeToPinching((zoom: number) => {
+                if (zoom < 0.6) {
+                    close();
                 }
             });
             return () => {
@@ -46,9 +64,9 @@ function App() {
                 ))}
             </div>
             {active !== null && (
-                <div className="overlay">
+                <div className={`overlay${closing ? " closing" : ""}`}>
                     <img ref={imgRef} src={images[active]} alt={`Full ${active + 1}`} />
-                    <button className="close-btn" onClick={() => setActive(null)}>
+                    <button className="close-btn" onClick={close}>
                         ✕
                     </button>
                 </div>


### PR DESCRIPTION
## Summary
- animate gallery image closing with fade and zoom-out
- allow pinch-to-close to trigger the animation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b83c1e5380832c9b88f193875fd910