### PR TITLE
feat: add end pinch subscription

### DIFF
--- a/src/Pinchable/Pinchable.spec.ts
+++ b/src/Pinchable/Pinchable.spec.ts
@@ -73,6 +73,7 @@ describe("Pinch", () => {
 
         const onPinch = RawPinchDetectorMock.mock.calls[0][0].onPinch;
         const onStart = RawPinchDetectorMock.mock.calls[0][0].onStart;
+        const onEnd = RawPinchDetectorMock.mock.calls[0][0].onEnd;
 
         return {
             pinchable: pinchable,
@@ -85,6 +86,9 @@ describe("Pinch", () => {
                 distance = val.distance ?? distance;
                 shift = val.shift ?? shift;
                 onPinch();
+            },
+            end() {
+                onEnd();
             },
         };
     }
@@ -748,6 +752,43 @@ describe("Pinch", () => {
             expect(cb).toHaveBeenCalledTimes(1);
             pinchable.dispose();
             move({ distance: 110 });
+            expect(cb).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("subscribeToEnd", () => {
+        test("calls callback on end", () => {
+            const { pinchable, start, end } = createPinch();
+            const cb = vi.fn();
+            pinchable.subscribeToEnd(cb);
+            start({ center: { x: 40, y: 40 }, distance: 50 });
+            end();
+            expect(cb).toHaveBeenCalledTimes(1);
+        });
+
+        test("unsubscribe removes callback", () => {
+            const { pinchable, start, end } = createPinch();
+            const cb = vi.fn();
+            const unsubscribe = pinchable.subscribeToEnd(cb);
+            start({ center: { x: 40, y: 40 }, distance: 50 });
+            end();
+            expect(cb).toHaveBeenCalledTimes(1);
+            unsubscribe();
+            start({ center: { x: 60, y: 60 }, distance: 70 });
+            end();
+            expect(cb).toHaveBeenCalledTimes(1);
+        });
+
+        test("dispose removes callback", () => {
+            const { pinchable, start, end } = createPinch();
+            const cb = vi.fn();
+            pinchable.subscribeToEnd(cb);
+            start({ center: { x: 40, y: 40 }, distance: 50 });
+            end();
+            expect(cb).toHaveBeenCalledTimes(1);
+            pinchable.dispose();
+            start({ center: { x: 60, y: 60 }, distance: 70 });
+            end();
             expect(cb).toHaveBeenCalledTimes(1);
         });
     });

--- a/src/Pinchable/Pinchable.ts
+++ b/src/Pinchable/Pinchable.ts
@@ -27,6 +27,7 @@ export class Pinchable implements Disposable {
     private enabled = true;
     private startPinchingNotifier = new Notifier<[]>();
     private pinchingNotifier = new Notifier<[number, { x: number; y: number }]>();
+    private endPinchingNotifier = new Notifier<[]>();
     // change one per pinch
     private center = { x: 0, y: 0 };
     private prevZoom = 1;
@@ -59,6 +60,7 @@ export class Pinchable implements Disposable {
             element: element,
             onStart: this.handleStart,
             onPinch: this.handlePinch,
+            onEnd: this.handleEnd,
         });
         this.disableAfterApply = new ResettableFlag(params.applyTime);
         this.element = new PinchedElementWrapper(element, params.applyTime);
@@ -70,6 +72,7 @@ export class Pinchable implements Disposable {
         this.element.dispose();
         this.startPinchingNotifier.dispose();
         this.pinchingNotifier.dispose();
+        this.endPinchingNotifier.dispose();
     }
 
     /**
@@ -125,6 +128,10 @@ export class Pinchable implements Disposable {
         return this.pinchingNotifier.subscribe(callback);
     }
 
+    public subscribeToEnd(callback: () => void): () => void {
+        return this.endPinchingNotifier.subscribe(callback);
+    }
+
     private handleStart = () => {
         this.prevDist = this.rawPinchDetector.distance;
         this.zoom = this.normalizedZoom;
@@ -159,6 +166,10 @@ export class Pinchable implements Disposable {
         });
         this.pinchingNotifier.emit(this.normalizedZoom, this.normalizedShift);
         this.prevDist = curDist;
+    };
+
+    private handleEnd = () => {
+        this.endPinchingNotifier.emit();
     };
 
     private get normalizedZoom() {

--- a/src/RawPinchDetector/RawPinchDetector.demo.ts
+++ b/src/RawPinchDetector/RawPinchDetector.demo.ts
@@ -25,6 +25,9 @@ function initRawPinchDetectorDemo() {
         onPinch: () => {
             update();
         },
+        onEnd: () => {
+            update();
+        },
     });
 
     const update = () => {

--- a/src/RawPinchDetector/RawPinchDetector.spec.ts
+++ b/src/RawPinchDetector/RawPinchDetector.spec.ts
@@ -10,6 +10,7 @@ describe("RawPinchDetector", () => {
     let events: UserEvent;
     const onStart = vi.fn();
     const onPinch = vi.fn();
+    const onEnd = vi.fn();
 
     beforeEach(() => {
         element = document.createElement("div");
@@ -17,10 +18,12 @@ describe("RawPinchDetector", () => {
         events = userEvent.setup();
         onStart.mockReset();
         onPinch.mockReset();
+        onEnd.mockReset();
         detector = new RawPinchDetector({
             element: element,
             onStart: onStart,
             onPinch: onPinch,
+            onEnd: onEnd,
         });
     });
 
@@ -48,6 +51,7 @@ describe("RawPinchDetector", () => {
             element: custom,
             onStart: vi.fn(),
             onPinch: vi.fn(),
+            onEnd: vi.fn(),
         });
         expect(custom.style.touchAction).toBe("none");
         localDetector.dispose();
@@ -72,6 +76,16 @@ describe("RawPinchDetector", () => {
         ]);
 
         expect(onPinch).toHaveBeenCalledTimes(1);
+    });
+
+    test("should invoke onEnd callback when user finishes pinching", async () => {
+        await asyncPointer([
+            { keys: "[TouchA>]", target: element, coords: { pageX: 10, pageY: 20 } },
+            { keys: "[TouchB>]", target: element, coords: { pageX: 50, pageY: 60 } },
+        ]);
+        await asyncPointer([{ keys: "[/TouchA]" }]);
+
+        expect(onEnd).toHaveBeenCalledTimes(1);
     });
 
     test("should calc center as a center between start fingers' positions", async () => {
@@ -187,6 +201,7 @@ describe("RawPinchDetector", () => {
                 element: element,
                 onStart: onStart,
                 onPinch: onPinch,
+                onEnd: onEnd,
             }).dispose();
             expect(addListenerSpy.mock.calls).toEqual(removeListenerSpy.mock.calls);
             addListenerSpy.mockRestore();

--- a/src/RawPinchDetector/RawPinchDetector.ts
+++ b/src/RawPinchDetector/RawPinchDetector.ts
@@ -10,6 +10,7 @@ export class RawPinchDetector implements Disposable {
     private elementPos = { top: 0, left: 0 };
     private readonly onStart: () => void;
     private readonly onPinch: () => void;
+    private readonly onEnd: () => void;
     private readonly activePointers: PointerEvent[] = [];
     private readonly startPointers: PointerEvent[] = [];
     private readonly disableAfterUp = new ResettableFlag(100);
@@ -17,10 +18,11 @@ export class RawPinchDetector implements Disposable {
         touchAction: string;
     };
 
-    public constructor(params: { element: HTMLElement; onStart: () => void; onPinch: () => void }) {
+    public constructor(params: { element: HTMLElement; onStart: () => void; onPinch: () => void; onEnd: () => void }) {
         this.element = params.element;
         this.onStart = params.onStart;
         this.onPinch = params.onPinch;
+        this.onEnd = params.onEnd;
 
         this.initialStyles = {
             touchAction: this.element.style.touchAction,
@@ -109,12 +111,16 @@ export class RawPinchDetector implements Disposable {
     };
 
     private handleUp = (event: PointerEvent) => {
+        const wasPinch = this.isPinch;
         const index = this.activePointers.findIndex(withId(event.pointerId));
         if (index !== -1) {
             this.activePointers.splice(index, 1);
             this.startPointers.splice(index, 1);
         }
         this.disableAfterUp.reset();
+        if (wasPinch && !this.isPinch) {
+            this.onEnd();
+        }
     };
 
     private get firstIndex(): number {


### PR DESCRIPTION
## Summary
- support end-of-pinch callback in RawPinchDetector
- add subscribeToEnd API in Pinchable
- cover new behavior with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba12440b7c832ca0e013d44fdbf951