### PR TITLE
feat: unify pinch event subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,18 @@ pinchable.focus({
 pinchable.setEnabled(false);
 pinchable.setEnabled(true);
 
+// Subscribe to events
+const unsubscribe = pinchable.subscribe("pinch", (zoom, shift) => {
+    console.log(zoom, shift);
+});
+// later
+unsubscribe();
+
 // Clean up when done
 pinchable.dispose();
 ```
+
+`subscribe()` lets you listen for gesture lifecycle events. Use `'start'` for the beginning of a gesture, `'pinch'` for updates with `zoom` and `shift`, and `'end'` for completion. The method returns an `unsubscribe` function.
 
 `minZoom` defaults to `1`, preventing zooming out beyond the original size. Set it lower to allow zooming out while keeping the element centered.
 

--- a/src/Pinchable/Pinchable.demo.html
+++ b/src/Pinchable/Pinchable.demo.html
@@ -39,6 +39,20 @@
                 align-items: center;
                 gap: 10px;
             }
+
+            .info-widget {
+                z-index: 10;
+                position: fixed;
+                bottom: 20px;
+                right: 20px;
+                min-width: 200px;
+                background-color: lightcoral;
+                opacity: 0.7;
+                padding: 8px 12px;
+                border-radius: 8px;
+                font-family: monospace;
+                white-space: pre-line;
+            }
         </style>
     </head>
     <body>
@@ -124,7 +138,7 @@
             </div>
         </article>
         <div class="pinchable-container" id="pinchContainer"></div>
-
+        <div id="infoWidget" class="info-widget">nothing happened</div>
         <script type="module" src="./Pinchable.demo.ts"></script>
     </body>
 </html>

--- a/src/Pinchable/Pinchable.demo.ts
+++ b/src/Pinchable/Pinchable.demo.ts
@@ -12,6 +12,15 @@ function createFillCanvas(container: HTMLElement): HTMLCanvasElement {
     return canvas;
 }
 
+function formatPoint(point: { x: number; y: number }): string {
+    return `[${point.x.toFixed(2)}, ${point.y.toFixed(2)}]`;
+}
+
+function getCurrentCenter(pinchable: Pinchable): { x: number; y: number } {
+    const internal = pinchable as unknown as { center: { x: number; y: number } };
+    return internal.center;
+}
+
 function drawPoint(canvas: HTMLCanvasElement, x: number, y: number): void {
     const ctx = canvas.getContext("2d");
     if (!ctx) {
@@ -91,6 +100,34 @@ export function initPinchableDemo(): void {
         return;
     }
 
+    const infoWidget = document.getElementById("infoWidget") as HTMLDivElement;
+
+    const subscribeToEvents = (instance: Pinchable): (() => void) => {
+        infoWidget.textContent = "nothing happened";
+
+        const unsubscribeStart = instance.subscribe("start", () => {
+            const center = getCurrentCenter(instance);
+            infoWidget.textContent = `center: ${formatPoint(center)}`;
+        });
+
+        const unsubscribePinch = instance.subscribe("pinch", (zoom, shift) => {
+            const center = getCurrentCenter(instance);
+            infoWidget.textContent =
+                `center: ${formatPoint(center)}\n` + `zoom: ${zoom.toFixed(2)}\n` + `shift: ${formatPoint(shift)}`;
+        });
+
+        const unsubscribeEnd = instance.subscribe("end", () => {
+            infoWidget.textContent = "ended";
+        });
+
+        return () => {
+            unsubscribeStart();
+            unsubscribePinch();
+            unsubscribeEnd();
+            infoWidget.textContent = "nothing happened";
+        };
+    };
+
     const canvas = createFillCanvas(container);
 
     // Draw reference points
@@ -116,6 +153,8 @@ export function initPinchableDemo(): void {
         zoomThreshold: zoomThreshold,
         shiftThreshold: shiftThreshold,
     });
+
+    let disposeSubscriptions = subscribeToEvents(pinchable);
 
     // Update value displays
     function updateValueDisplays(): void {
@@ -166,6 +205,7 @@ export function initPinchableDemo(): void {
     });
 
     function reinitializePinchable(): void {
+        disposeSubscriptions();
         pinchable.dispose();
         pinchable = new Pinchable(container, {
             maxZoom: maxZoom,
@@ -175,6 +215,7 @@ export function initPinchableDemo(): void {
             zoomThreshold: zoomThreshold,
             shiftThreshold: shiftThreshold,
         });
+        disposeSubscriptions = subscribeToEvents(pinchable);
     }
 
     // Button actions

--- a/src/Pinchable/Pinchable.spec.ts
+++ b/src/Pinchable/Pinchable.spec.ts
@@ -679,11 +679,11 @@ describe("Pinch", () => {
         });
     });
 
-    describe("subscribeToStartPinching", () => {
+    describe("subscribe start event", () => {
         test("calls callback on start", () => {
             const { pinchable, start } = createPinch();
             const cb = vi.fn();
-            pinchable.subscribeToStartPinching(cb);
+            pinchable.subscribe("start", cb);
             start({ center: { x: 40, y: 40 }, distance: 50 });
             expect(cb).toHaveBeenCalledTimes(1);
             start({ center: { x: 60, y: 60 }, distance: 70 });
@@ -693,7 +693,7 @@ describe("Pinch", () => {
         test("unsubscribe removes callback", () => {
             const { pinchable, start } = createPinch();
             const cb = vi.fn();
-            const unsubscribe = pinchable.subscribeToStartPinching(cb);
+            const unsubscribe = pinchable.subscribe("start", cb);
             start({ center: { x: 40, y: 40 }, distance: 50 });
             expect(cb).toHaveBeenCalledTimes(1);
             unsubscribe();
@@ -704,7 +704,7 @@ describe("Pinch", () => {
         test("dispose removes callback", () => {
             const { pinchable, start } = createPinch();
             const cb = vi.fn();
-            pinchable.subscribeToStartPinching(cb);
+            pinchable.subscribe("start", cb);
             start({ center: { x: 40, y: 40 }, distance: 50 });
             expect(cb).toHaveBeenCalledTimes(1);
             pinchable.dispose();
@@ -713,11 +713,11 @@ describe("Pinch", () => {
         });
     });
 
-    describe("subscribeToPinching", () => {
+    describe("subscribe pinch event", () => {
         test("calls callback on pinch", () => {
             const { pinchable, start, move } = createPinch();
             const cb = vi.fn();
-            pinchable.subscribeToPinching(cb);
+            pinchable.subscribe("pinch", cb);
             start({ center: { x: 40, y: 40 }, distance: 50 });
             move({ distance: 105 });
             expect(cb).toHaveBeenCalledWith(2, { x: -40, y: -40 });
@@ -726,7 +726,7 @@ describe("Pinch", () => {
         test("calls callback on focus", () => {
             const { pinchable } = createPinch();
             const cb = vi.fn();
-            pinchable.subscribeToPinching(cb);
+            pinchable.subscribe("pinch", cb);
             pinchable.focus({ zoom: 2, to: { x: 0.5, y: 0.5 } });
             expect(cb).toHaveBeenCalledWith(2, { x: -150, y: -100 });
         });
@@ -734,7 +734,7 @@ describe("Pinch", () => {
         test("unsubscribe removes callback", () => {
             const { pinchable, start, move } = createPinch();
             const cb = vi.fn();
-            const unsubscribe = pinchable.subscribeToPinching(cb);
+            const unsubscribe = pinchable.subscribe("pinch", cb);
             start({ center: { x: 40, y: 40 }, distance: 50 });
             move({ distance: 105 });
             expect(cb).toHaveBeenCalledTimes(1);
@@ -746,7 +746,7 @@ describe("Pinch", () => {
         test("dispose removes callback", () => {
             const { pinchable, start, move } = createPinch();
             const cb = vi.fn();
-            pinchable.subscribeToPinching(cb);
+            pinchable.subscribe("pinch", cb);
             start({ center: { x: 40, y: 40 }, distance: 50 });
             move({ distance: 105 });
             expect(cb).toHaveBeenCalledTimes(1);
@@ -756,11 +756,11 @@ describe("Pinch", () => {
         });
     });
 
-    describe("subscribeToEnd", () => {
+    describe("subscribe end event", () => {
         test("calls callback on end", () => {
             const { pinchable, start, end } = createPinch();
             const cb = vi.fn();
-            pinchable.subscribeToEnd(cb);
+            pinchable.subscribe("end", cb);
             start({ center: { x: 40, y: 40 }, distance: 50 });
             end();
             expect(cb).toHaveBeenCalledTimes(1);
@@ -769,7 +769,7 @@ describe("Pinch", () => {
         test("unsubscribe removes callback", () => {
             const { pinchable, start, end } = createPinch();
             const cb = vi.fn();
-            const unsubscribe = pinchable.subscribeToEnd(cb);
+            const unsubscribe = pinchable.subscribe("end", cb);
             start({ center: { x: 40, y: 40 }, distance: 50 });
             end();
             expect(cb).toHaveBeenCalledTimes(1);
@@ -782,7 +782,7 @@ describe("Pinch", () => {
         test("dispose removes callback", () => {
             const { pinchable, start, end } = createPinch();
             const cb = vi.fn();
-            pinchable.subscribeToEnd(cb);
+            pinchable.subscribe("end", cb);
             start({ center: { x: 40, y: 40 }, distance: 50 });
             end();
             expect(cb).toHaveBeenCalledTimes(1);

--- a/src/Pinchable/Pinchable.ts
+++ b/src/Pinchable/Pinchable.ts
@@ -4,6 +4,12 @@ import { ResettableFlag } from "../ResettableFlag";
 import type { Disposable } from "../Disposable";
 import { Notifier } from "../Notifier";
 
+type PinchEventsParams = {
+    start: [];
+    pinch: [number, { x: number; y: number }];
+    end: [];
+};
+
 const nonStart = -1;
 const defaultZoomThreshold = 0.2;
 const defaultShiftThreshold = 10;
@@ -25,9 +31,11 @@ export class Pinchable implements Disposable {
     private element: PinchedElementWrapper;
     private disableAfterApply: ResettableFlag;
     private enabled = true;
-    private startPinchingNotifier = new Notifier<[]>();
-    private pinchingNotifier = new Notifier<[number, { x: number; y: number }]>();
-    private endPinchingNotifier = new Notifier<[]>();
+    private notifiers: { [K in keyof PinchEventsParams]: Notifier<PinchEventsParams[K]> } = {
+        start: new Notifier<[]>(),
+        pinch: new Notifier<[number, { x: number; y: number }]>(),
+        end: new Notifier<[]>(),
+    };
     // change one per pinch
     private center = { x: 0, y: 0 };
     private prevZoom = 1;
@@ -70,9 +78,9 @@ export class Pinchable implements Disposable {
         this.rawPinchDetector.dispose();
         this.disableAfterApply.dispose();
         this.element.dispose();
-        this.startPinchingNotifier.dispose();
-        this.pinchingNotifier.dispose();
-        this.endPinchingNotifier.dispose();
+        this.notifiers.start.dispose();
+        this.notifiers.pinch.dispose();
+        this.notifiers.end.dispose();
     }
 
     /**
@@ -113,23 +121,29 @@ export class Pinchable implements Disposable {
             translate: this.normalizedShift,
             withTransition: true,
         });
-        this.pinchingNotifier.emit(this.normalizedZoom, this.normalizedShift);
+        this.notifiers.pinch.emit(this.normalizedZoom, this.normalizedShift);
     }
 
     public setEnabled(enabled: boolean): void {
         this.enabled = enabled;
     }
 
-    public subscribeToStartPinching(callback: () => void): () => void {
-        return this.startPinchingNotifier.subscribe(callback);
-    }
-
-    public subscribeToPinching(callback: (zoom: number, shift: { x: number; y: number }) => void): () => void {
-        return this.pinchingNotifier.subscribe(callback);
-    }
-
-    public subscribeToEnd(callback: () => void): () => void {
-        return this.endPinchingNotifier.subscribe(callback);
+    /**
+     * Subscribe to pinch events.
+     *
+     * @param event The event type to listen for.
+     *              - `"start"` fires when a pinch gesture begins.
+     *              - `"pinch"` fires continuously while the gesture is active,
+     *                providing the current zoom level and shift.
+     *              - `"end"` fires when the gesture ends.
+     * @param callback Callback invoked with event-specific arguments.
+     * @returns A function to unsubscribe the callback.
+     */
+    public subscribe<E extends keyof PinchEventsParams>(
+        event: E,
+        callback: (...args: PinchEventsParams[E]) => void,
+    ): () => void {
+        return this.notifiers[event].subscribe(callback);
     }
 
     private handleStart = () => {
@@ -144,7 +158,7 @@ export class Pinchable implements Disposable {
             x: (center.x - this.shift.x) / this.zoom,
             y: (center.y - this.shift.y) / this.zoom,
         };
-        this.startPinchingNotifier.emit();
+        this.notifiers.start.emit();
     };
 
     private handlePinch = () => {
@@ -164,12 +178,12 @@ export class Pinchable implements Disposable {
             translate: this.normalizedShift,
             withTransition: false,
         });
-        this.pinchingNotifier.emit(this.normalizedZoom, this.normalizedShift);
+        this.notifiers.pinch.emit(this.normalizedZoom, this.normalizedShift);
         this.prevDist = curDist;
     };
 
     private handleEnd = () => {
-        this.endPinchingNotifier.emit();
+        this.notifiers.end.emit();
     };
 
     private get normalizedZoom() {


### PR DESCRIPTION
## Summary
- replace separate subscribe helpers with typed `subscribe` accepting `start`, `pinch`, or `end`
- consolidate event notifiers into a keyed map and rename type to `PinchEventsParams`
- keep React demo on legacy subscription API for now

## Testing
- `npm test -- --run`
- `npm run typecheck`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2c4cd4644832ca9697214558553e1