### PR TITLE
Update react-demo to pinchable v0.3.0

### DIFF
--- a/react-demo/package-lock.json
+++ b/react-demo/package-lock.json
@@ -8,7 +8,7 @@
             "name": "react-demo",
             "version": "0.0.0",
             "dependencies": {
-                "pinchable": "^0.2.0",
+                "pinchable": "^0.3.0",
                 "react": "^19.1.1",
                 "react-dom": "^19.1.1"
             },
@@ -2814,9 +2814,9 @@
             }
         },
         "node_modules/pinchable": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/pinchable/-/pinchable-0.2.0.tgz",
-            "integrity": "sha512-1XU4uULExOBKyjarTtZ/JzKDht6AuMiaPXubFID0sB9vT5Eg20u8PtwEIj9qHZwOPaN9IjWXw00lrtdSNr2e6w==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/pinchable/-/pinchable-0.3.0.tgz",
+            "integrity": "sha512-kPUKRzLNVVxNLZWp4YKunhyED6WtJ9XtC2/QBBKcuddDqLBSe9oMkVp1GZNBrpkp98q0BXcgKN/a/REI1F9C3A==",
             "license": "MIT"
         },
         "node_modules/postcss": {

--- a/react-demo/package.json
+++ b/react-demo/package.json
@@ -11,7 +11,7 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "pinchable": "^0.2.0",
+        "pinchable": "^0.3.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
     },

--- a/react-demo/src/App.tsx
+++ b/react-demo/src/App.tsx
@@ -40,25 +40,18 @@ function App() {
                 nearZeroZoomThreshold: 0,
             });
 
-            let lastZoom = 1;
-
-            const unsubscribePinch = pinch.subscribe("pinch", (zoom: number) => {
-                lastZoom = zoom;
-            });
-
-            const unsubscribeEnd = pinch.subscribe("end", () => {
-                if (lastZoom < 0.7) {
+            const unsubscribeEnd = pinch.subscribe("end", (zoom: number) => {
+                if (zoom < 0.7) {
                     close();
                     return;
                 }
 
-                if (lastZoom < 1) {
+                if (zoom < 1) {
                     pinch.focus({ zoom: 1, to: { x: 0.5, y: 0.5 } });
                 }
             });
 
             return () => {
-                unsubscribePinch();
                 unsubscribeEnd();
                 pinch.dispose();
             };


### PR DESCRIPTION
## Summary
- bump the react demo's pinchable dependency to v0.3.0
- use the zoom payload from the pinch end event to handle closing/reset logic without tracking intermediate state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e8c9cdd2a8832c86dd7deedd94099b