### PR TITLE
Update README demo section with Vue link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ Lightweight, dependency-free wrapper that adds mobile-friendly pinch-zoom and pa
 
 ## Demo
 
-Interactive demo: https://pinch-six.vercel.app/
+Try Pinchable in one of the hosted demos:
 
-React demo: https://pinch-react-demo.vercel.app/
+- Interactive playground: https://pinch-six.vercel.app/
+- React demo: https://pinch-react-demo.vercel.app/
+- Vue demo: https://pinch-vue-demo.vercel.app/
 
 ## Features
 


### PR DESCRIPTION
## Summary
- add the hosted Vue demo link alongside the existing demos
- polish the demo section copy so the list reads more clearly

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e8eaca9de8832cb392a13039ee1884